### PR TITLE
Suggests extra brackets to first take square then divide

### DIFF
--- a/pstalgo/src/analyses/AngularIntegration.cpp
+++ b/pstalgo/src/analyses/AngularIntegration.cpp
@@ -71,11 +71,11 @@ PSTADllExport void PSTAAngularIntegrationSyntaxNormalizeLengthWeight(const float
 PSTADllExport void PSTAAngularIntegrationHillierNormalize(const unsigned int* N, const float* TD, unsigned int count, float* out_normalized_score)
 {
 	for (unsigned int i = 0; i < count; ++i)
-		out_normalized_score[i] = (float)N[i]*(float)N[i] / (TD[i] + 1.0f);
+		out_normalized_score[i] = ((float)N[i]*(float)N[i]) / (TD[i] + 1.0f);
 }
 
 PSTADllExport void PSTAAngularIntegrationHillierNormalizeLengthWeight(const float* reached_length, const float* TDL, unsigned int count, float* out_normalized_score)
 {
 	for (unsigned int i = 0; i < count; ++i)
-		out_normalized_score[i] = reached_length[i]*reached_length[i] / (TDL[i] + 1.0f);
+		out_normalized_score[i] = (reached_length[i]*reached_length[i]) / (TDL[i] + 1.0f);
 }


### PR DESCRIPTION
The hillier normalisation is the square of nodes divided by TD so these extra brackets would enforce the squaring before the division.